### PR TITLE
Add license, port to .NET 5.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+﻿Copyright (c) 2009
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-## UsmDemuxer - a simple demuxer
+# UsmDemuxer - a simple demuxer
 
-Code copied from [VGMToolBox](https://github.com/jeeb/vgmtoolbox/)  
-License unknown?
+Code copied from [VGMToolbox](https://sourceforge.net/p/vgmtoolbox/code/)
 
 ## Build
-Drag into Visual Studio, or build with mono `xbuild UsmDemuxer.sln`
 
+Drag into Visual Studio, or build with mono `xbuild UsmDemuxer.sln`

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Code copied from [VGMToolbox](https://sourceforge.net/p/vgmtoolbox/code/)
 
 ## Build
 
-Drag into Visual Studio, or build with mono `xbuild UsmDemuxer.sln`
+Drag into Visual Studio, or build with `dotnet build`.

--- a/UsmDemuxer/App.config
+++ b/UsmDemuxer/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-</configuration>

--- a/UsmDemuxer/UsmDemuxer.csproj
+++ b/UsmDemuxer/UsmDemuxer.csproj
@@ -1,74 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{73CC08C0-E1EF-4D1B-80F4-A3DAC74835E0}</ProjectGuid>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UsmDemuxer</RootNamespace>
-    <AssemblyName>UsmDemuxer</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="System.CodeDom" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="VGMToolbox\format\CriUsmStream.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VGMToolbox\format\Mpeg1Stream.cs" />
-    <Compile Include="VGMToolbox\format\MpegStream.cs" />
-    <Compile Include="VGMToolbox\format\SofdecStream.cs" />
-    <Compile Include="VGMToolbox\util\ByteConversion.cs" />
-    <Compile Include="VGMToolbox\util\ByteSearchCalculatingOffsetDescription.cs" />
-    <Compile Include="VGMToolbox\util\CalculatingOffsetDescription.cs" />
-    <Compile Include="VGMToolbox\util\Constants.cs" />
-    <Compile Include="VGMToolbox\util\FileUtil.cs" />
-    <Compile Include="VGMToolbox\util\IDeepCopy.cs" />
-    <Compile Include="VGMToolbox\util\MathUtil.cs" />
-    <Compile Include="VGMToolbox\util\OffsetDescription.cs" />
-    <Compile Include="VGMToolbox\util\ParseFile.cs" />
-    <Compile Include="VGMToolbox\util\RiffCalculatingOffsetDescription.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/UsmDemuxer/VGMToolbox/util/ParseFile.cs
+++ b/UsmDemuxer/VGMToolbox/util/ParseFile.cs
@@ -1508,7 +1508,7 @@ namespace VGMToolbox.util
                     {
                         fileItem = GetNextVfsRecord(headerFs, vfsInformation, currentOffset, currentFileCount, sourcePath, outputFolderPath);
                     }
-                    catch(Exception exp)
+                    catch(Exception)
                     {
                         //throw new Exception("foo", exp);
                     }
@@ -1654,7 +1654,6 @@ namespace VGMToolbox.util
                             break;
                         default:
                             throw new Exception("Invalid relative location type for relative file name offset.");
-                            break;
                     }
                 }
 
@@ -1804,7 +1803,6 @@ namespace VGMToolbox.util
                         break;
                     default:
                         throw new InvalidDataException("Unknown relative location string for RIFF: " + offsetInfo.RelativeLocationToRiffChunkString);
-                        break;
                 }
 
                 // get the value
@@ -1894,7 +1892,6 @@ namespace VGMToolbox.util
                         break;
                     default:
                         throw new InvalidDataException("Unknown relative location string for bytes string search: " + offsetInfo.RelativeLocationToByteString);
-                        break;
                 }
 
                 // get the value


### PR DESCRIPTION
First of all, thanks for your utility. I found it quite useful and wanted to share what [try-convert](https://github.com/dotnet/try-convert) did when I attempted to build the project for GNU/Linux – it did convert the csproj, but the result needed some manual editing.

Commit messages are quite self-descriptive, but here are some notes.

1. VGMToolbox seems to have a MIT license: <https://sourceforge.net/p/vgmtoolbox/code/HEAD/tree/VGMToolbox/LICENSE.txt>

   I added it. You may want to change it to any other license that is compatible with MIT, if you want to.

1. Porting to .NET 5.0 allows this utility to work under GNU/Linux.

   Building for the current platform is very simple. Just run `dotnet build` in the repo root or in the `UsmDemuxer` dir. To make a release build, add `-c Release`.

   I tested the build for a specific runtime, `linux-x64`, as well:

   ```shell
   # Run in the repo root
   $ dotnet build -r linux-x64 -c Release UsmDemuxer

   # Same as above
   $ cd UsmDemuxer
   $ dotnet build -r linux-x64 -c Release
   ```

   Tested with .NET SDK 5.0.202 and .NET runtime 5.0.5.

   I also did the same test for `win-x86 win-x64 win7-x64 win81-x64 win10-x64` runtimes. The project compiles successfully and runs fine under Wine. I did not test this on Windows, but it should work there just as well.

   I don't have Visual Studio to test if the project works with it, nor do I know what is the minimum VS version for .NET 5. The solution file may need to be adjusted.

1. UsmDemuxer compiles without warnings and runs without any issues. It produces the same output for every kind of build that I tested.